### PR TITLE
retouch_design

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,5 @@ gem 'carrierwave'
 gem 'acts-as-taggable-on'
 gem 'jquery-turbolinks'
 gem 'bullet'
+gem 'kaminari'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
       railties (>= 3.1.0)
       turbolinks
     json (1.8.3)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -215,6 +218,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   jquery-turbolinks
+  kaminari
   mysql2 (>= 0.3.13, < 0.5)
   pry-rails
   rails (= 4.2.5)

--- a/app/controllers/prototypes/newests_controller.rb
+++ b/app/controllers/prototypes/newests_controller.rb
@@ -2,5 +2,4 @@ class Prototypes::NewestsController < ApplicationController
   def index
     @prototypes = Prototype.includes(:user, :tags).order("created_at DESC").page(params[:page]).per(8)
   end
-  end
 end

--- a/app/controllers/prototypes/newests_controller.rb
+++ b/app/controllers/prototypes/newests_controller.rb
@@ -1,5 +1,5 @@
 class Prototypes::NewestsController < ApplicationController
   def index
-    @prototypes = Prototype.includes(:user, :tags).order("created_at DESC").page(params[:page]).per(8)
+    @prototypes = Prototype.includes(:user, :tags).order("created_at DESC").page params[:page]
   end
 end

--- a/app/controllers/prototypes/newests_controller.rb
+++ b/app/controllers/prototypes/newests_controller.rb
@@ -1,5 +1,6 @@
 class Prototypes::NewestsController < ApplicationController
   def index
-    @prototypes = Prototype.includes(:user, :tags).order("created_at DESC")
+    @prototypes = Prototype.includes(:user, :tags).order("created_at DESC").page(params[:page]).per(8)
+  end
   end
 end

--- a/app/controllers/prototypes/newests_controller.rb
+++ b/app/controllers/prototypes/newests_controller.rb
@@ -1,5 +1,5 @@
 class Prototypes::NewestsController < ApplicationController
   def index
-    @prototypes = Prototype.includes(:user, :tags).order("created_at DESC").page params[:page]
+    @prototypes = Prototype.includes(:user, :tags).order("created_at DESC").page(params[:page])
   end
 end

--- a/app/controllers/prototypes/populars_controller.rb
+++ b/app/controllers/prototypes/populars_controller.rb
@@ -1,5 +1,5 @@
 class Prototypes::PopularsController < ApplicationController
   def index
-    @prototypes = Prototype.eager_load(:user, :tags).order('likes_count DESC').page params[:page]
+    @prototypes = Prototype.eager_load(:user, :tags).order('likes_count DESC').page(params[:page])
   end
 end

--- a/app/controllers/prototypes/populars_controller.rb
+++ b/app/controllers/prototypes/populars_controller.rb
@@ -1,5 +1,5 @@
 class Prototypes::PopularsController < ApplicationController
   def index
-    @prototypes = Prototype.eager_load(:user, :tags).order('likes_count DESC').page(params[:page]).per(8)
+    @prototypes = Prototype.eager_load(:user, :tags).order('likes_count DESC').page params[:page]
   end
 end

--- a/app/controllers/prototypes/populars_controller.rb
+++ b/app/controllers/prototypes/populars_controller.rb
@@ -1,5 +1,5 @@
 class Prototypes::PopularsController < ApplicationController
   def index
-    @prototypes = Prototype.eager_load(:user, :tags).order('likes_count DESC')
+    @prototypes = Prototype.eager_load(:user, :tags).order('likes_count DESC').page(params[:page]).per(8)
   end
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -14,6 +14,8 @@ class Prototype < ActiveRecord::Base
   # acts_as_taggable_on :tags のエイリアス(prototype.tag_list)
   acts_as_ordered_taggable_on :prototypes
 
+  paginates_per 8
+
   def content_main
     if contents.main.present?
       contents.main[0].content

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,12 @@
+-#  Link to the "First" page
+-#  available local variables
+-#    url:           url to the first page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%li.page-item.prev{ class: "#{'disabled' if current_page.first?}" }
+  = link_to (current_page.first? ? "#" : url), class: "page-link", "aria-label" => "First", :remote => remote do
+    %span{"aria-hidden" => "true"} «
+    %span.sr-only
+      = t('views.pagination.first').html_safe

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,9 @@
+-#  Non-link tag that stands for skipped pages...
+-#  available local variables
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%li.page-item.gap
+  .page-link
+    = t('views.pagination.truncate').html_safe

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,12 @@
+-#  Link to the "Last" page
+-#  available local variables
+-#    url:           url to the last page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%li.page-item.next{ class: "#{'disabled' if current_page.last?}" }
+  = link_to (current_page.last? ? "#" : url), class: "page-link", "aria-label" => "Last", :remote => remote do
+    %span{"aria-hidden" => "true"} »
+    %span.sr-only
+      = t('views.pagination.last').html_safe

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,12 @@
+-#  Link to the "Next" page
+-#  available local variables
+-#    url:           url to the next page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%li.page-item.next{ class: "#{'disabled' if current_page.last?}" }
+  = link_to (current_page.last? ? "#" : url), class: "page-link", "aria-label" => "Next", :remote => remote do
+    %span{"aria-hidden" => "true"} ›
+    %span.sr-only
+      = t('views.pagination.next').html_safe

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,13 @@
+-#  Link showing page number
+-#  available local variables
+-#    page:          a page object for "this" page
+-#    url:           url to this page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%li.page-item{ class: "#{'active' if page.current?}" }
+  = link_to url, class: "page-link", remote: remote do
+    = page
+    - if page.current?
+      %span.sr-only (current)

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,18 @@
+-#  The container tag
+-#  available local variables
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+-#    paginator:     the paginator that renders the pagination tags inside
+= paginator.render do
+  %nav.pagination
+    = first_page_tag unless current_page.first?
+    = prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.left_outer? || page.right_outer? || page.inside_window?
+        = page_tag page
+      - elsif !page.was_truncated?
+        = gap_tag
+    = next_page_tag unless current_page.last?
+    = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,12 @@
+-#  Link to the "Previous" page
+-#  available local variables
+-#    url:           url to the previous page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%li.page-item.prev{ class: "#{'disabled' if current_page.first?}" }
+  = link_to (current_page.first? ? "#" : url), class: "page-link", "aria-label" => "Previous", :remote => remote do
+    %span{"aria-hidden" => "true"} ‹
+    %span.sr-only
+      = t('views.pagination.previous').html_safe

--- a/app/views/prototypes/newests/index.html.haml
+++ b/app/views/prototypes/newests/index.html.haml
@@ -17,22 +17,4 @@
     = render partial: "prototypes/index", locals: {prototypes: @prototypes}
 
 .text-center
-  %ul.pagination
-    %li.disabled
-      %a{"aria-label" => "Previous", href: "#"}
-        %span{"aria-hidden" => "true"} «
-    %li.active
-      %a{href: "#"}
-        1
-        %span.sr-only (current)
-    %li
-      %a{href: "#"} 2
-    %li
-      %a{href: "#"} 3
-    %li
-      %a{href: "#"} 4
-    %li
-      %a{href: "#"} 5
-    %li
-      / %a{"aria-label": "Next", href: "#"}
-      /   %span{"aria-hidden": "true"} »
+  = paginate @prototypes

--- a/app/views/prototypes/populars/index.html.haml
+++ b/app/views/prototypes/populars/index.html.haml
@@ -16,22 +16,4 @@
   .row
     = render partial: "prototypes/index", locals: {prototypes: @prototypes}
 .text-center
-  %ul.pagination
-    %li.disabled
-      %a{"aria-label" => "Previous", href: "#"}
-        %span{"aria-hidden" => "true"} «
-    %li.active
-      %a{href: "#"}
-        1
-        %span.sr-only (current)
-    %li
-      %a{href: "#"} 2
-    %li
-      %a{href: "#"} 3
-    %li
-      %a{href: "#"} 4
-    %li
-      %a{href: "#"} 5
-    %li
-      / %a{"aria-label": "Next", href: "#"}
-      /   %span{"aria-hidden": "true"} »
+  = paginate @prototypes


### PR DESCRIPTION
# WHAT
- ページネーションの機能の実装
- 全体のデザインの修正
# WHY
- ページを分けて投稿されたprototypeを表示させるため。
- viewを整え、見た目をきれいにするため。
